### PR TITLE
Add database migration logic Azure -> OnCluster

### DIFF
--- a/api/v1alpha1/dbmmomysql_types.go
+++ b/api/v1alpha1/dbmmomysql_types.go
@@ -76,6 +76,7 @@ type DBMMOMYSQLDeployment struct {
 	ConfigurationName *string            `json:"configurationName,omitempty"`
 	StorageCapacity   *string            `json:"storageCapacity,omitempty"`
 	DeploymentType    *string            `json:"deploymentType,omitempty"`
+	ConfirmMigrate    *bool              `json:"confirmMigrate,omitempty"`
 	EnvFrom           []v1.EnvFromSource `json:"envFrom,omitempty"`
 	ServerCredentials *MysqlCredentials  `json:"serverCredentials,omitempty"`
 	AzureConfig       *AzureConfig       `json:"azureConfig,omitempty"`

--- a/api/v1alpha1/dbmmomysql_types.go
+++ b/api/v1alpha1/dbmmomysql_types.go
@@ -121,6 +121,7 @@ type DBMMOMySQLStatus struct {
 	Nodes                  []string    `json:"nodes,omitempty"`
 	Services               []string    `json:"services,omitempty"`
 	PersistentVolumeClaims []string    `json:"persistentVolumeClaims,omitempty"`
+	MigrationInProgress    bool        `json:"migrationInProgress,omitempty"`
 	AzureStatus            AzureStatus `json:"azureStatus,omitempty"`
 }
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -210,6 +210,11 @@ func (in *DBMMOMYSQLDeployment) DeepCopyInto(out *DBMMOMYSQLDeployment) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ConfirmMigrate != nil {
+		in, out := &in.ConfirmMigrate, &out.ConfirmMigrate
+		*out = new(bool)
+		**out = **in
+	}
 	if in.EnvFrom != nil {
 		in, out := &in.EnvFrom, &out.EnvFrom
 		*out = make([]v1.EnvFromSource, len(*in))

--- a/config/crd/bases/cache.my.domain_dbmmomysqls.yaml
+++ b/config/crd/bases/cache.my.domain_dbmmomysqls.yaml
@@ -288,6 +288,8 @@ spec:
                         type: string
                     type: object
                 type: object
+              migrationInProgress:
+                type: boolean
               nodes:
                 items:
                   type: string

--- a/config/crd/bases/cache.my.domain_dbmmomysqls.yaml
+++ b/config/crd/bases/cache.my.domain_dbmmomysqls.yaml
@@ -190,6 +190,8 @@ spec:
                     type: object
                   configurationName:
                     type: string
+                  confirmMigrate:
+                    type: boolean
                   deploymentType:
                     type: string
                   envFrom:

--- a/controllers/model/mysql_ingress.go
+++ b/controllers/model/mysql_ingress.go
@@ -7,7 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// GetMysqlIngress returns the default ingress configuration for a mysql isntance
+// GetMysqlIngress returns the default ingress configuration for a mysql instance
 func GetMysqlIngress(m *v1alpha1.DBMMOMySQL) *netv1.Ingress {
 	ingr := &netv1.Ingress{
 		TypeMeta: metav1.TypeMeta{},

--- a/controllers/mysql/dbmmomysql_on_cluster_reconciler.go
+++ b/controllers/mysql/dbmmomysql_on_cluster_reconciler.go
@@ -76,7 +76,7 @@ func (r *DBMMOMySQLReconciler) onClusterReconcileMysqlStatus(ctx context.Context
 		}
 	}
 	r.Log.Info("Reconciled Mysql status ", "Mysql.Namespace", mysql.Namespace, "Mysql.Name", mysql.Name)
-	return ctrl.Result{Requeue: true}, nil
+	return ctrl.Result{}, nil
 }
 
 func (r *DBMMOMySQLReconciler) onClusterReconcileMysqlDeployment(ctx context.Context, mysql *cachev1alpha1.DBMMOMySQL) (ctrl.Result, error) {

--- a/controllers/util/azure_helper.go
+++ b/controllers/util/azure_helper.go
@@ -54,7 +54,7 @@ func CreateServer(ctx context.Context, m *v1alpha1.DBMMOMySQL) (server mysql.Ser
 				AdministratorLoginPassword: getAdministratorLoginPassword(m),
 				Version:                    mysql.FiveFullStopSeven, // 5.7
 				StorageProfile: &mysql.StorageProfile{
-					StorageMB: to.Int32Ptr(524288),
+					StorageMB: to.Int32Ptr(1024),
 				},
 			},
 		})


### PR DESCRIPTION
- adds database migration logic from Azure to OnCluster (does not care for data _yet_) 