### PR TITLE
fix oncluster deletion post migration to azure

### DIFF
--- a/controllers/mysql/dbmmomysql_azure_reconciler.go
+++ b/controllers/mysql/dbmmomysql_azure_reconciler.go
@@ -55,11 +55,11 @@ func (r *DBMMOMySQLReconciler) azureReconcileStatus(ctx context.Context, mysql *
 
 	if err := r.Client.Status().Update(ctx, mysql); err != nil {
 		r.Log.Error(err, "Failed to update Mysql status", "Mysql.Namespace", mysql.Namespace, "Mysql.Name", mysql.Name)
-		return ctrl.Result{}, err
+		return ctrl.Result{RequeueAfter: constants.ReconcilerRequeueDelayOnFail}, err
 	}
 
 	r.Log.Info("Reconciled MySQL on Azure status ", "Mysql.Namespace", mysql.Namespace, "Mysql.Name", mysql.Name)
-	return ctrl.Result{RequeueAfter: constants.ReconcilerRequeueDelay}, nil
+	return ctrl.Result{}, nil
 }
 
 func (r *DBMMOMySQLReconciler) azureCleanup(ctx context.Context, mysql *cachev1alpha1.DBMMOMySQL) (ctrl.Result, error) {

--- a/controllers/mysql/dbmmomysql_on_cluster_reconciler.go
+++ b/controllers/mysql/dbmmomysql_on_cluster_reconciler.go
@@ -251,7 +251,6 @@ func (r *DBMMOMySQLReconciler) OnClusterCleanup(ctx context.Context, m *cachev1a
 	if err := r.Client.Delete(ctx, dep); err != nil && !k8serr.IsNotFound(err) {
 		return ctrl.Result{RequeueAfter: constants.ReconcilerRequeueDelayOnFail}, err
 	}
-
 	// Don't requeue if the cleanup was successful
 	return ctrl.Result{}, nil
 }


### PR DESCRIPTION
- Fix conditional deletion after migrating to azure, previously resources would remain on the cluster even after migration has been confirmed